### PR TITLE
April22 update

### DIFF
--- a/docs/qatlib/revision_history.html
+++ b/docs/qatlib/revision_history.html
@@ -123,12 +123,16 @@
 </tr>
 </thead>
 <tbody>
-<tr class="row-even"><td><p>004</p></td>
+<tr class="row-even"><td><p>005</p></td>
+<td><p>Corrected VF mapping in QAT Virtual Function example.</p></td>
+<td><p>April 2025</p></td>
+</tr>
+<tr class="row-odd"><td><p>004</p></td>
 <td><p>Added instructions for installing later QATlib and QAT_Engine
 version on Ubuntu24.04.</p></td>
 <td><p>Jan 2025</p></td>
 </tr>
-<tr class="row-odd"><td><p>003</p></td>
+<tr class="row-even"><td><p>003</p></td>
 <td><p>Updated for qatlib 23.11 release.
 Added: - Support DC NS (NoSession) APIs.
 - Support DC compressBound APIs.
@@ -138,14 +142,14 @@ Added: - Support DC NS (NoSession) APIs.
 - Added “Running in a Virtual Machine” section.</p></td>
 <td><p>Nov 2023</p></td>
 </tr>
-<tr class="row-even"><td><p>002</p></td>
+<tr class="row-odd"><td><p>002</p></td>
 <td><p>Updated for qatlib 23.08 release.
 Updated qatlib configuration to include full possibilities,
 updated text of Performance Considerations.
 Added “Kernel/OS Requirements” table to Requirements section.</p></td>
 <td><p>Sept 2023</p></td>
 </tr>
-<tr class="row-odd"><td><p>001</p></td>
+<tr class="row-even"><td><p>001</p></td>
 <td><p>Added “Kernel/OS Requirements” table to Requirements section. See</p></td>
 <td><p>June 2023</p></td>
 </tr>

--- a/docs/qatlib/running_in_vm.html
+++ b/docs/qatlib/running_in_vm.html
@@ -244,7 +244,7 @@ to the VM.</p>
 <span class="go">&lt;/hostdev&gt;</span>
 <span class="go">&lt;hostdev mode=&#39;subsystem&#39; type=&#39;pci&#39; managed=&#39;yes&#39;&gt;</span>
 <span class="go">    &lt;source&gt;</span>
-<span class="go">        &lt;address domain=&#39;0x0000&#39; bus=&#39;0x70&#39; slot=&#39;0x00&#39; function=&#39;0x3&#39;/&gt;</span>
+<span class="go">        &lt;address domain=&#39;0x0000&#39; bus=&#39;0x70&#39; slot=&#39;0x00&#39; function=&#39;0x4&#39;/&gt;</span>
 <span class="go">    &lt;/source&gt;</span>
 <span class="go">    &lt;address type=&#39;pci&#39; domain=&#39;0x0000&#39; bus=&#39;0x08&#39; slot=&#39;0x00&#39; function=&#39;0x1&#39;/&gt;</span>
 <span class="go">&lt;/hostdev&gt;</span>


### PR DESCRIPTION
Includes the following updates: 
                
Update running_in_vm.rst #205
<address domain='0x0000' bus='0x70' slot='0x00' function='0x3'/>
<address domain='0x0000' bus='0x70' slot='0x00' function='0x4'/>

Update revision_history.rst #206
005          | Corrected VF mapping in QAT Virtual Function example.             | April 2025|