### PR TITLE
Revised the description of the `cy` option in the docs/PG/configuration_files_maxprocesscalculations.html

### DIFF
--- a/docs/PG/configuration_files_maxprocesscalculations.html
+++ b/docs/PG/configuration_files_maxprocesscalculations.html
@@ -169,7 +169,7 @@ the services needed, the number of instances can be increased.</p>
 <tr class="row-even"><td><p><code class="docutils literal notranslate"><span class="pre">cy</span></code></p></td>
 <td><p>128</p></td>
 <td><p>Invalid</p></td>
-<td><p>Compression and symmetric crypto service not available.</p></td>
+<td><p>Compression services will not be available.</p></td>
 </tr>
 <tr class="row-odd"><td><p><code class="docutils literal notranslate"><span class="pre">dc</span></code></p></td>
 <td><p>128</p></td>


### PR DESCRIPTION
Revised the description of the `cy` option in the document (it should be consistent with `sym;asym`).